### PR TITLE
Add direct RISC0 prover support via Bonsai SDK as fallback when Boundless is not configured

### DIFF
--- a/crates/nitro-attest-cli/src/debug.rs
+++ b/crates/nitro-attest-cli/src/debug.rs
@@ -36,7 +36,7 @@ pub struct DebugDocCli {
 
 impl DebugDocCli {
     /// Executes attestation document inspection and display.
-    /// 
+    ///
     /// This method parses the attestation report and displays detailed information
     /// about the attestation document and certificate chain, including:
     /// - Module ID and timestamp
@@ -48,16 +48,16 @@ impl DebugDocCli {
         let report = AttestationReport::parse(&std::fs::read(&self.report)?)?;
         let cert_chain = report.cert_chain()?;
         let doc = report.doc();
-        
+
         // Display attestation document information
         tracing::info!("Doc:");
         tracing::info!("\tModule ID: {}", doc.module_id);
-        
+
         // Convert and display timestamp in human-readable format
         let timestamp = ASN1Time::from_timestamp(doc.timestamp as i64 / 1000)?;
         tracing::info!("\tTimestamp: {}({})", timestamp, timestamp.timestamp());
         tracing::info!("\tDigest: {}", doc.digest);
-        
+
         // Display optional fields if present
         if let Some(data) = &doc.public_key {
             tracing::info!("\tPublicKey: {}", Bytes::copy_from_slice(data));
@@ -68,7 +68,7 @@ impl DebugDocCli {
         if let Some(data) = &doc.nonce {
             tracing::info!("\tNonce: {}", Bytes::copy_from_slice(data));
         }
-        
+
         // Display non-zero PCR values
         for (k, v) in &doc.pcrs {
             let v = Bytes48::from(v);
@@ -77,7 +77,7 @@ impl DebugDocCli {
             }
             tracing::info!("\tPCR[{}]: {}", k, v);
         }
-        
+
         // Display certificate chain information
         tracing::info!("Cert Chain:");
         let digest = cert_chain.digest();

--- a/crates/nitro-attest-cli/src/proof.rs
+++ b/crates/nitro-attest-cli/src/proof.rs
@@ -18,10 +18,10 @@ use crate::utils::{ContractArgs, ProverArgs};
 pub enum ProofCli {
     /// Verify a proof on-chain using smart contract
     VerifyOnChain(ProofVerifyOnChainCli),
-    
+
     /// Generate composite proofs for single attestation reports  
     GenComposite(ProofGenCompositeCli),
-    
+
     /// Aggregate multiple proofs into a single proof
     Aggregate(ProofAggregateCli),
 }
@@ -51,7 +51,7 @@ pub struct ProofVerifyOnChainCli {
 
 impl ProofVerifyOnChainCli {
     /// Executes on-chain proof verification.
-    /// 
+    ///
     /// This method submits a proof to the smart contract for verification,
     /// ensuring the proof was generated correctly and corresponds to valid
     /// Nitro Enclave attestation data.
@@ -63,7 +63,7 @@ impl ProofVerifyOnChainCli {
 
         // Load and parse the proof file
         let result = OnchainProof::decode_json(&std::fs::read(&self.proof)?)?;
-        
+
         // Validate that the proof contains on-chain verification data
         if result.onchain_proof.len() == 0 {
             return Err(anyhow::anyhow!(
@@ -101,12 +101,12 @@ pub struct ProofAggregateCli {
 
 impl ProofAggregateCli {
     /// Executes proof aggregation.
-    /// 
+    ///
     /// Combines multiple individual proofs into a single aggregated proof,
     /// enabling efficient batch verification of multiple attestation reports.
     pub fn run(&self) -> anyhow::Result<()> {
         set_prover_dev_mode(self.prover.dev);
-        
+
         // Validate that proof files are provided
         if self.proof.is_empty() {
             return Err(anyhow!(
@@ -124,7 +124,7 @@ impl ProofAggregateCli {
         // Initialize prover and contract interface
         let contract = self.contract.stub()?;
         let prover = self.prover.new_prover(contract)?;
-        
+
         // Aggregate the proofs into a single proof
         let aggregated_proof = prover.aggregate_proofs(proofs)?;
         let aggregated_proof =
@@ -162,19 +162,19 @@ pub struct ProofGenCompositeCli {
 
 impl ProofGenCompositeCli {
     /// Executes composite proof generation.
-    /// 
+    ///
     /// Creates a composite proof structure that can be used for more
     /// complex verification scenarios or as input to aggregation.
     pub fn run(&self) -> anyhow::Result<()> {
         set_prover_dev_mode(self.prover.dev);
-        
+
         // Read the attestation report file
         let raw_report = std::fs::read(&self.report)?;
 
         // Initialize prover and contract interface
         let contract = self.contract.stub()?;
         let prover = self.prover.new_prover(contract)?;
-        
+
         // Prepare inputs and generate composite proof
         let inputs = prover.prepare_verifier_inputs(vec![raw_report])?;
         let composite_proof = prover.gen_multi_composite_proofs(&inputs)?.remove(0);

--- a/crates/nitro-attest-cli/src/prove.rs
+++ b/crates/nitro-attest-cli/src/prove.rs
@@ -12,20 +12,20 @@ use clap::Args;
 use crate::utils::{ContractArgs, ProverArgs};
 
 /// Command-line arguments for the prove subcommand.
-/// 
+///
 /// Generates zero-knowledge proofs from one or more Nitro Enclave attestation reports.
 /// Supports both single report verification and multi-report aggregation.
 #[derive(Args)]
 pub struct ProveCli {
     /// Path(s) to Nitro Enclave attestation report files
-    /// 
+    ///
     /// Can specify multiple report files to generate an aggregated proof.
     /// Each file should contain a binary attestation report from AWS Nitro Enclaves.
     #[arg(long)]
     report: Vec<PathBuf>,
 
     /// Output file path for the generated proof
-    /// 
+    ///
     /// If not specified, the proof will only be printed to stdout.
     /// The output format is JSON containing the proof data and metadata.
     #[arg(long)]
@@ -42,7 +42,7 @@ pub struct ProveCli {
 
 impl ProveCli {
     /// Executes the proof generation command.
-    /// 
+    ///
     /// This method orchestrates the entire proof generation process:
     /// 1. Configures the prover with development mode settings
     /// 2. Validates input parameters
@@ -65,10 +65,10 @@ impl ProveCli {
 
         // Initialize smart contract interface (if configured)
         let contract = self.contract.stub()?;
-        
+
         // Create the prover instance with the specified configuration
         let prover = self.prover.new_prover(contract)?;
-        
+
         // Generate proof based on the number of input reports
         let result = if raw_reports.len() == 1 {
             prover.prove_attestation_report(raw_reports.remove(0))?
@@ -80,7 +80,7 @@ impl ProveCli {
         if let Some(out) = &self.out {
             std::fs::write(out, result.encode_json()?)?;
         }
-        
+
         // Display proof information to stdout
         println!("proof: {:?}", result);
 

--- a/crates/nitro-attest-cli/src/upload.rs
+++ b/crates/nitro-attest-cli/src/upload.rs
@@ -11,7 +11,7 @@ use clap::Args;
 use crate::utils::ProverArgs;
 
 /// Command-line arguments for uploading ZK programs to remote proving services.
-/// 
+///
 /// This enables distributed proof generation by uploading the necessary program
 /// images to SP1 or RISC0 remote proving infrastructure.
 #[derive(Args)]
@@ -20,7 +20,7 @@ pub struct UploadCli {
     prover: ProverArgs,
 
     /// Output file path for storing the program identifier
-    /// 
+    ///
     /// The program ID is needed for setup the NitroEnclaveVerifierContract.
     /// If not specified, the program ID will only be displayed to stdout.
     #[clap(long)]
@@ -29,7 +29,7 @@ pub struct UploadCli {
 
 impl UploadCli {
     /// Executes the program upload command.
-    /// 
+    ///
     /// This method:
     /// 1. Disables development mode (uploads require production builds)
     /// 2. Creates a prover instance without contract binding
@@ -38,7 +38,7 @@ impl UploadCli {
     pub fn run(&self) -> anyhow::Result<()> {
         // Force network prover for uploads (dev mode programs cannot be uploaded)
         set_prover_dev_mode(false);
-        
+
         // Create prover without contract binding (uploads don't need contracts)
         let prover = self.prover.new_prover(None)?;
         let result = prover.upload_program_images()?;

--- a/crates/nitro-attest-cli/src/utils.rs
+++ b/crates/nitro-attest-cli/src/utils.rs
@@ -97,11 +97,17 @@ impl ProverArgs {
         let prover_count = {
             let mut count = 0;
             #[cfg(feature = "risc0")]
-            if self.risc0 { count += 1; }
+            if self.risc0 {
+                count += 1;
+            }
             #[cfg(feature = "sp1")]
-            if self.sp1 { count += 1; }
+            if self.sp1 {
+                count += 1;
+            }
             #[cfg(feature = "pico")]
-            if self.pico { count += 1; }
+            if self.pico {
+                count += 1;
+            }
             count
         };
 
@@ -167,7 +173,7 @@ impl ProverArgs {
 }
 
 /// Command-line arguments for configuring smart contract interaction.
-/// 
+///
 /// Used for on-chain proof verification and other blockchain operations.
 #[derive(Args, Clone)]
 pub struct ContractArgs {

--- a/crates/prover/src/contract.rs
+++ b/crates/prover/src/contract.rs
@@ -89,7 +89,9 @@ impl NitroEnclaveVerifierContract {
         let proof_bytes = proof.onchain_proof.clone();
         let zk = proof.zktype;
         let zk_config = self.zk_config(proof.zktype).await?;
-        let verifier_proof_id = self.get_verifier_proof_id(proof.zktype, zk_config.verifierId).await?;
+        let verifier_proof_id = self
+            .get_verifier_proof_id(proof.zktype, zk_config.verifierId)
+            .await?;
         proof.program_id.verify(&zk_config, verifier_proof_id)?;
 
         Ok(match proof.proof_type {

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -20,7 +20,7 @@ pub use program_risc0::{ProgramRisc0, RiscZeroProverConfig};
 #[cfg(feature = "pico")]
 pub mod program_pico;
 #[cfg(feature = "pico")]
-pub use program_pico::{ProgramPico, PicoProverConfig};
+pub use program_pico::{PicoProverConfig, ProgramPico};
 
 pub fn set_prover_dev_mode(_dev_mode: bool) {
     #[cfg(feature = "sp1")]

--- a/crates/prover/src/program_pico.rs
+++ b/crates/prover/src/program_pico.rs
@@ -89,7 +89,12 @@ impl<Input, Output> ProgramPico<Input, Output> {
                     let need_setup = !vm_pk_path.exists();
 
                     // Prove with EVM backend (KoalaBear)
-                    client.prove_evm_with_deferred(stdin_builder, need_setup, &output_path, "kb")?;
+                    client.prove_evm_with_deferred(
+                        stdin_builder,
+                        need_setup,
+                        &output_path,
+                        "kb",
+                    )?;
 
                     // Read proof.data - first 8 elements of 32-byte values
                     let proof_file = output_path.join("proof.data");

--- a/crates/prover/src/program_risc0.rs
+++ b/crates/prover/src/program_risc0.rs
@@ -27,8 +27,8 @@ use risc0_methods::{
     RISC0_AGGREGATOR_ELF, RISC0_AGGREGATOR_ID, RISC0_VERIFIER_ELF, RISC0_VERIFIER_ID,
 };
 use risc0_zkvm::{
-    default_executor, Digest, ExecutorEnv, InnerReceipt, Receipt, ReceiptClaim, VERSION,
-    compute_image_id,
+    default_executor, default_prover, Digest, ExecutorEnv, InnerReceipt, ProverOpts, Receipt,
+    ReceiptClaim, VERSION, compute_image_id,
 };
 use serde::Serialize;
 
@@ -311,6 +311,22 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
         })
     }
 
+    /// Direct proving via risc0-zkvm's default_prover() (Bonsai, local, or IPC).
+    /// Generates a real Groth16 proof without going through the Boundless network.
+    fn gen_proof_direct(&self, input_bytes: &[u8]) -> anyhow::Result<RawProof> {
+        let env = ExecutorEnv::builder()
+            .write_slice(input_bytes)
+            .build()?;
+
+        let prover = default_prover();
+        let opts = ProverOpts::groth16();
+        let prove_info = prover.prove_with_opts(env, self.elf, &opts)?;
+        let receipt = prove_info.receipt;
+
+        let journal: Bytes = receipt.journal.bytes.clone().into();
+        Ok(RawProof::from_proof(&receipt, journal)?)
+    }
+
     /// Dev mode: execute aggregator zkVM without proof generation.
     /// Deserializes full Receipts from bincode-encoded data.
     fn gen_dev_aggregated_proof(
@@ -564,16 +580,24 @@ where
             }
         } else {
             let cfg = RiscZeroProverConfig::default();
+            let use_boundless = cfg.rpc_url.is_some() && cfg.private_key.is_some();
+
             if is_aggregation {
+                if !use_boundless {
+                    return Err(anyhow!("Aggregation requires Boundless (set BOUNDLESS_RPC_URL and BOUNDLESS_PRIVATE_KEY)"));
+                }
                 // Boundless aggregation: deserialize receipts and submit to aggregator
                 Self::gen_proof_boundless_aggregated(
                     &input_bytes,
                     encoded_composite_proofs.unwrap(),
                     &cfg,
                 )
-            } else {
+            } else if use_boundless {
                 // Boundless single proof
                 self.gen_proof_boundless(&input_bytes, raw_proof_type, &cfg)
+            } else {
+                // Direct proving via risc0 default_prover() (Bonsai, local, or IPC)
+                self.gen_proof_direct(&input_bytes)
             }
         }
     }

--- a/crates/prover/src/program_risc0.rs
+++ b/crates/prover/src/program_risc0.rs
@@ -18,8 +18,7 @@ use boundless_market::{
     contracts::FulfillmentData,
     request_builder::OfferParams,
     storage::storage_provider_from_env,
-    Deployment,
-    StorageProvider,
+    Deployment, StorageProvider,
 };
 use lazy_static::lazy_static;
 use risc0_ethereum_contracts::{groth16, receipt::decode_seal_with_claim};
@@ -27,8 +26,8 @@ use risc0_methods::{
     RISC0_AGGREGATOR_ELF, RISC0_AGGREGATOR_ID, RISC0_VERIFIER_ELF, RISC0_VERIFIER_ID,
 };
 use risc0_zkvm::{
-    default_executor, default_prover, Digest, ExecutorEnv, InnerReceipt, ProverOpts, Receipt,
-    ReceiptClaim, VERSION, compute_image_id,
+    compute_image_id, default_executor, default_prover, Digest, ExecutorEnv, InnerReceipt,
+    ProverOpts, Receipt, ReceiptClaim, VERSION,
 };
 use serde::Serialize;
 
@@ -111,21 +110,27 @@ impl RiscZeroProverConfig {
 
     /// Get effective min price (config or default: 0.0001 gwei)
     pub fn effective_min_price(&self) -> U256 {
-        self.min_price
-            .map(U256::from)
-            .unwrap_or_else(|| parse_units(Self::DEFAULT_MIN_PRICE_GWEI, "gwei").unwrap().into())
+        self.min_price.map(U256::from).unwrap_or_else(|| {
+            parse_units(Self::DEFAULT_MIN_PRICE_GWEI, "gwei")
+                .unwrap()
+                .into()
+        })
     }
 
     /// Get effective max price (config or default: 0.001 gwei)
     pub fn effective_max_price(&self) -> U256 {
-        self.max_price
-            .map(U256::from)
-            .unwrap_or_else(|| parse_units(Self::DEFAULT_MAX_PRICE_GWEI, "gwei").unwrap().into())
+        self.max_price.map(U256::from).unwrap_or_else(|| {
+            parse_units(Self::DEFAULT_MAX_PRICE_GWEI, "gwei")
+                .unwrap()
+                .into()
+        })
     }
 
     /// Get effective collateral (default: 10 ETH)
     pub fn effective_collateral(&self) -> U256 {
-        parse_units(Self::DEFAULT_COLLATERAL_ETH, "ether").unwrap().into()
+        parse_units(Self::DEFAULT_COLLATERAL_ETH, "ether")
+            .unwrap()
+            .into()
     }
 
     /// Get effective timeout with buffer
@@ -296,9 +301,7 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
 
     /// Dev mode: execute zkVM without proof generation
     fn gen_dev_proof(&self, input_bytes: &[u8]) -> anyhow::Result<RawProof> {
-        let env = ExecutorEnv::builder()
-            .write_slice(input_bytes)
-            .build()?;
+        let env = ExecutorEnv::builder().write_slice(input_bytes).build()?;
 
         let executor = default_executor();
         let session = executor.execute(env, self.elf)?;
@@ -314,9 +317,7 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
     /// Direct proving via risc0-zkvm's default_prover() (Bonsai, local, or IPC).
     /// Generates a real Groth16 proof without going through the Boundless network.
     fn gen_proof_direct(&self, input_bytes: &[u8]) -> anyhow::Result<RawProof> {
-        let env = ExecutorEnv::builder()
-            .write_slice(input_bytes)
-            .build()?;
+        let env = ExecutorEnv::builder().write_slice(input_bytes).build()?;
 
         let prover = default_prover();
         let opts = ProverOpts::groth16();
@@ -350,8 +351,7 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
         let receipts: Vec<Receipt> = encoded_proofs
             .iter()
             .map(|encoded_receipt| {
-                bincode::deserialize(encoded_receipt)
-                    .context("Failed to deserialize Receipt")
+                bincode::deserialize(encoded_receipt).context("Failed to deserialize Receipt")
             })
             .collect::<anyhow::Result<_>>()?;
 
@@ -368,9 +368,7 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
         framed_input.extend_from_slice(&input_frame);
 
         // Execute aggregator in dev mode
-        let env = ExecutorEnv::builder()
-            .write_slice(&framed_input)
-            .build()?;
+        let env = ExecutorEnv::builder().write_slice(&framed_input).build()?;
 
         let executor = default_executor();
         let session = executor.execute(env, RISC0_AGGREGATOR_ELF)?;
@@ -379,6 +377,57 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
             encoded_proof: Bytes::new(), // Empty proof in dev mode
             journal: session.journal.bytes.clone().into(),
         })
+    }
+
+    /// Direct aggregation via risc0-zkvm's default_prover() (Bonsai, local, or IPC).
+    /// Registers inner receipts as assumptions so the aggregator guest can verify them.
+    fn gen_proof_direct_aggregated(
+        input_bytes: &[u8],
+        encoded_proofs: &[&Bytes],
+    ) -> anyhow::Result<RawProof> {
+        let batch_input = BatchVerifierJournal::decode(input_bytes)
+            .context("Failed to decode BatchVerifierJournal")?;
+
+        if encoded_proofs.len() != batch_input.outputs.len() {
+            return Err(anyhow!(
+                "Number of proofs ({}) must match number of outputs ({})",
+                encoded_proofs.len(),
+                batch_input.outputs.len()
+            ));
+        }
+
+        let receipts: Vec<Receipt> = encoded_proofs
+            .iter()
+            .map(|encoded_receipt| {
+                bincode::deserialize(encoded_receipt).context("Failed to deserialize Receipt")
+            })
+            .collect::<anyhow::Result<_>>()?;
+
+        let aggregator_input = AggregatorInput {
+            input_bytes: input_bytes.to_vec(),
+            receipts: receipts.clone(),
+        };
+
+        let input_frame = postcard::to_allocvec(&aggregator_input)
+            .context("Failed to serialize aggregator input with postcard")?;
+        let mut framed_input = Vec::with_capacity(4 + input_frame.len());
+        framed_input.extend_from_slice(&(input_frame.len() as u32).to_le_bytes());
+        framed_input.extend_from_slice(&input_frame);
+
+        let mut env_builder = ExecutorEnv::builder();
+        env_builder.write_slice(&framed_input);
+        for receipt in &receipts {
+            env_builder.add_assumption(receipt.clone());
+        }
+        let env = env_builder.build()?;
+
+        let prover = default_prover();
+        let opts = ProverOpts::groth16();
+        let prove_info = prover.prove_with_opts(env, RISC0_AGGREGATOR_ELF, &opts)?;
+        let receipt = prove_info.receipt;
+
+        let journal: Bytes = receipt.journal.bytes.clone().into();
+        RawProof::from_proof(&receipt, journal)
     }
 
     /// Production: generate proof via Boundless network.
@@ -395,7 +444,8 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
 
         block_on(async {
             let (seal_bytes, journal_bytes) =
-                Self::submit_boundless_request(input_bytes, self.elf, cfg, program_url, true).await?;
+                Self::submit_boundless_request(input_bytes, self.elf, cfg, program_url, true)
+                    .await?;
 
             // Construct Receipt from fulfillment - stores full Receipt for aggregation
             let receipt = Self::construct_receipt(seal_bytes, journal_bytes.clone(), image_id)?;
@@ -429,8 +479,7 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
         let receipts: Vec<Receipt> = encoded_proofs
             .iter()
             .map(|encoded_receipt| {
-                bincode::deserialize(encoded_receipt)
-                    .context("Failed to deserialize Receipt")
+                bincode::deserialize(encoded_receipt).context("Failed to deserialize Receipt")
             })
             .collect::<anyhow::Result<_>>()?;
 
@@ -449,12 +498,19 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
         let program_url = cfg.aggregator_program_url.as_deref();
 
         block_on(async {
-            let (seal_bytes, journal_bytes) =
-                Self::submit_boundless_request(&framed_input, RISC0_AGGREGATOR_ELF, cfg, program_url, true).await?;
+            let (seal_bytes, journal_bytes) = Self::submit_boundless_request(
+                &framed_input,
+                RISC0_AGGREGATOR_ELF,
+                cfg,
+                program_url,
+                true,
+            )
+            .await?;
 
             // Construct Receipt from fulfillment (seal has selector prefix)
             let aggregator_image_id = compute_image_id(RISC0_AGGREGATOR_ELF)?;
-            let receipt = Self::construct_receipt(seal_bytes, journal_bytes.clone(), aggregator_image_id)?;
+            let receipt =
+                Self::construct_receipt(seal_bytes, journal_bytes.clone(), aggregator_image_id)?;
 
             Ok(RawProof::from_proof(&receipt, journal_bytes.into())?)
         })
@@ -481,12 +537,8 @@ impl<Input, Output> ProgramRisc0<Input, Output> {
         // - Extracts correct verifier parameters from the selector
         // - Handles Groth16, FakeReceipt, and SetVerifier seal types
         let claim = ReceiptClaim::ok(image_id, journal.clone());
-        let receipt = decode_seal_with_claim(
-            alloy_primitives::Bytes::from(seal),
-            claim,
-            journal,
-        )
-        .context("Failed to decode seal")?;
+        let receipt = decode_seal_with_claim(alloy_primitives::Bytes::from(seal), claim, journal)
+            .context("Failed to decode seal")?;
 
         receipt
             .receipt()
@@ -583,15 +635,18 @@ where
             let use_boundless = cfg.rpc_url.is_some() && cfg.private_key.is_some();
 
             if is_aggregation {
-                if !use_boundless {
-                    return Err(anyhow!("Aggregation requires Boundless (set BOUNDLESS_RPC_URL and BOUNDLESS_PRIVATE_KEY)"));
+                if use_boundless {
+                    Self::gen_proof_boundless_aggregated(
+                        &input_bytes,
+                        encoded_composite_proofs.unwrap(),
+                        &cfg,
+                    )
+                } else {
+                    Self::gen_proof_direct_aggregated(
+                        &input_bytes,
+                        encoded_composite_proofs.unwrap(),
+                    )
                 }
-                // Boundless aggregation: deserialize receipts and submit to aggregator
-                Self::gen_proof_boundless_aggregated(
-                    &input_bytes,
-                    encoded_composite_proofs.unwrap(),
-                    &cfg,
-                )
             } else if use_boundless {
                 // Boundless single proof
                 self.gen_proof_boundless(&input_bytes, raw_proof_type, &cfg)

--- a/crates/prover/src/prover.rs
+++ b/crates/prover/src/prover.rs
@@ -9,9 +9,7 @@ use crate::{
 use alloy_primitives::Bytes;
 use anyhow::{anyhow, bail, Context};
 use aws_nitro_enclave_attestation_verifier::{
-    stub::{
-        BatchVerifierJournal, VerifierInput, VerifierJournal, ZkCoProcessorType,
-    },
+    stub::{BatchVerifierJournal, VerifierInput, VerifierJournal, ZkCoProcessorType},
     AttestationReport,
 };
 
@@ -666,16 +664,18 @@ impl NitroEnclaveProver {
             Some(verifier_contract) => {
                 // make sure the zk config aligned
                 let zk_config = block_on(verifier_contract.zk_config(self.verifier.zktype()))?;
-                let verifier_proof_id = block_on(verifier_contract.get_verifier_proof_id(
-                    self.verifier.zktype(),
-                    zk_config.verifierId,
-                ))?;
+                let verifier_proof_id = block_on(
+                    verifier_contract
+                        .get_verifier_proof_id(self.verifier.zktype(), zk_config.verifierId),
+                )?;
                 max_time_diff = block_on(verifier_contract.max_time_diff())?;
 
                 let program_id = self.get_program_id();
-                let verify_result = program_id.verify(&zk_config, verifier_proof_id).with_context(|| {
-                    format!("Failed to verify zkconfig for {:?}", self.verifier.zktype())
-                });
+                let verify_result = program_id
+                    .verify(&zk_config, verifier_proof_id)
+                    .with_context(|| {
+                        format!("Failed to verify zkconfig for {:?}", self.verifier.zktype())
+                    });
                 if let Err(verify_err) = verify_result {
                     if !self.cfg.skip_contract_program_id_check {
                         bail!(

--- a/crates/prover/src/types.rs
+++ b/crates/prover/src/types.rs
@@ -74,7 +74,11 @@ pub struct ProgramId {
 }
 
 impl ProgramId {
-    pub fn verify(&self, zk_config: &ZkCoProcessorConfig, verifier_proof_id: B256) -> anyhow::Result<()> {
+    pub fn verify(
+        &self,
+        zk_config: &ZkCoProcessorConfig,
+        verifier_proof_id: B256,
+    ) -> anyhow::Result<()> {
         if zk_config.aggregatorId != self.aggregator_id
             || zk_config.verifierId != self.verifier_id
             || verifier_proof_id != self.verifier_proof_id

--- a/crates/risc0-methods/build.rs
+++ b/crates/risc0-methods/build.rs
@@ -69,8 +69,7 @@ fn main() {
         file,
         r#"pub const RISC0_VERIFIER_ELF: &[u8] = include_bytes!({:?});
 pub const RISC0_AGGREGATOR_ELF: &[u8] = include_bytes!({:?});"#,
-        elf_paths.0,
-        elf_paths.1
+        elf_paths.0, elf_paths.1
     )
     .unwrap();
 

--- a/crates/utils/src/wasm/mod.rs
+++ b/crates/utils/src/wasm/mod.rs
@@ -57,10 +57,12 @@ pub fn encode_verified_journal(journal: JsValue) -> Vec<u8> {
 /// A JavaScript array of VerifierJournal objects (see parse_verified_journal for format)
 #[wasm_bindgen]
 pub fn parse_batch_verified_journal(bytes: &[u8]) -> JsValue {
-    let journals = <Vec<VerifierJournal>>::abi_decode(bytes)
-        .expect("Failed to decode VerifierJournal[]");
-    let wrappers: Vec<VerifierJournalWrapper> =
-        journals.into_iter().map(VerifierJournalWrapper::from).collect();
+    let journals =
+        <Vec<VerifierJournal>>::abi_decode(bytes).expect("Failed to decode VerifierJournal[]");
+    let wrappers: Vec<VerifierJournalWrapper> = journals
+        .into_iter()
+        .map(VerifierJournalWrapper::from)
+        .collect();
     serde_wasm_bindgen::to_value(&wrappers).expect("Failed to serialize to JsValue")
 }
 

--- a/crates/utils/src/wrapper.rs
+++ b/crates/utils/src/wrapper.rs
@@ -266,5 +266,4 @@ mod tests {
         assert_eq!(journal.pcrs.len(), roundtrip.pcrs.len());
         assert_eq!(journal.moduleId, roundtrip.moduleId);
     }
-
 }

--- a/crates/verifier/src/stub.rs
+++ b/crates/verifier/src/stub.rs
@@ -32,7 +32,9 @@ impl Bytes48 {
         self.first.is_zero() && self.second.is_zero()
     }
     pub fn to_bytes(&self) -> Bytes {
-        [self.first.as_slice(), self.second.as_slice()].concat().into()
+        [self.first.as_slice(), self.second.as_slice()]
+            .concat()
+            .into()
     }
 }
 

--- a/crates/verifier/src/verifier.rs
+++ b/crates/verifier/src/verifier.rs
@@ -14,7 +14,8 @@ pub fn verify_attestation_report(input: &VerifierInput) -> anyhow::Result<Verifi
     let report = AttestationReport::parse(&input.attestationReport)?;
 
     let doc = report.doc();
-    let cert_chain = report.authenticate(input.trustedCertsPrefixLen as usize, doc.timestamp / 1000)?;
+    let cert_chain =
+        report.authenticate(input.trustedCertsPrefixLen as usize, doc.timestamp / 1000)?;
 
     let user_data = get_option_bytes(&doc.user_data);
     let nonce = get_option_bytes(&doc.nonce);

--- a/crates/x509-verifier-rust-crypto/src/constants.rs
+++ b/crates/x509-verifier-rust-crypto/src/constants.rs
@@ -3,22 +3,22 @@
 use x509_parser::der_parser::{oid, Oid};
 
 // Key Algo OIDs
-pub const OID_KEY_ALGO_EC: Oid = oid!(1.2.840.10045.2.1);
-pub const OID_KEY_ALGO_PKCS1_V1_5: Oid = oid!(1.2.840.113549.1.1.1);
+pub const OID_KEY_ALGO_EC: Oid = oid!(1.2.840 .10045 .2 .1);
+pub const OID_KEY_ALGO_PKCS1_V1_5: Oid = oid!(1.2.840 .113549 .1 .1 .1);
 
 pub const EC_KEY_ALGO_OID: &str = "1.2.840.10045.2.1";
 
-pub const OLD_KEY_ALGO_PARAM_P256: Oid = oid!(1.2.840.10045.3.1.7);
-pub const OLD_KEY_ALGO_PARAM_P384: Oid = oid!(1.3.132.0.34);
+pub const OLD_KEY_ALGO_PARAM_P256: Oid = oid!(1.2.840 .10045 .3 .1 .7);
+pub const OLD_KEY_ALGO_PARAM_P384: Oid = oid!(1.3.132 .0 .34);
 pub const EC_KEY_P256_PARAM_OID: &str = "1.2.840.10045.3.1.7";
 pub const EC_KEY_P384_PARAM_OID: &str = "1.3.132.0.34";
 pub const RSA_PKCS1_V1_5_KEY_OID: &str = "1.2.840.113549.1.1.1";
 
 // Signature Algo OIDs
-pub const OID_SIG_ALGO_ECDSA_SHA256: Oid = oid!(1.2.840.10045.4.3.2);
-pub const OID_SIG_ALGO_ECDSA_SHA384: Oid = oid!(1.2.840.10045.4.3.3);
-pub const OID_SIG_ALGO_RSASSA_PSS: Oid = oid!(1.2.840.113549.1.1.10);
-pub const OID_SIG_ALGO_RSA_SHA256: Oid = oid!(1.2.840.113549.1.1.11);
+pub const OID_SIG_ALGO_ECDSA_SHA256: Oid = oid!(1.2.840 .10045 .4 .3 .2);
+pub const OID_SIG_ALGO_ECDSA_SHA384: Oid = oid!(1.2.840 .10045 .4 .3 .3);
+pub const OID_SIG_ALGO_RSASSA_PSS: Oid = oid!(1.2.840 .113549 .1 .1 .10);
+pub const OID_SIG_ALGO_RSA_SHA256: Oid = oid!(1.2.840 .113549 .1 .1 .11);
 pub const ECDSA_SHA256_OID: &str = "1.2.840.10045.4.3.2";
 pub const ECDSA_SHA384_OID: &str = "1.2.840.10045.4.3.3";
 pub const RSASSA_PSS_OID: &str = "1.2.840.113549.1.1.10";

--- a/crates/x509-verifier-rust-crypto/src/lib.rs
+++ b/crates/x509-verifier-rust-crypto/src/lib.rs
@@ -2,24 +2,24 @@
 
 #[cfg(feature = "pico")]
 pub extern crate sha2_pico as sha2;
-#[cfg(feature = "sp1")]
-pub extern crate sha2_sp1 as sha2;
 #[cfg(all(feature = "risc0", not(feature = "sp1"), not(feature = "pico")))]
 pub extern crate sha2_risc0 as sha2;
+#[cfg(feature = "sp1")]
+pub extern crate sha2_sp1 as sha2;
 #[cfg(all(not(feature = "sp1"), not(feature = "risc0"), not(feature = "pico")))]
 pub use sha2;
 
-#[cfg(feature = "sp1")]
-pub extern crate p256_sp1 as p256;
 #[cfg(all(feature = "risc0_unstable", not(feature = "sp1")))]
 pub extern crate p256_risc0 as p256;
+#[cfg(feature = "sp1")]
+pub extern crate p256_sp1 as p256;
 #[cfg(all(not(feature = "sp1"), not(feature = "risc0_unstable")))]
 pub use p256;
 
-#[cfg(feature = "sp1")]
-pub extern crate rsa_sp1 as rsa;
 #[cfg(all(feature = "risc0_unstable", not(feature = "sp1")))]
 pub extern crate rsa_risc0 as rsa;
+#[cfg(feature = "sp1")]
+pub extern crate rsa_sp1 as rsa;
 #[cfg(all(not(feature = "sp1"), not(feature = "risc0_unstable")))]
 pub use rsa;
 


### PR DESCRIPTION
## Summary
- Add direct RISC0 proving via `default_prover()` (Bonsai SDK, local, or IPC) as a fallback when Boundless environment variables are not set, for both single proofs and aggregation.
- Add `gen_proof_direct_aggregated` method that handles receipt deserialization, postcard framing, and registers inner receipts as assumptions for guest-side verification.
- Ran `cargo fmt`, `cargo clippy`, and verified successful build with no new warnings.