### PR TITLE
fix(contracts): align SP1 verifier deployment with v6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,9 @@ $ cd contracts
 $ forge script script/NitroEnclaveVerifier.s.sol --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --sig 'deployVerifier()'
 
 # Deploy the SP1Verifier
-# If you want to use the official pre-deployed contract, please refer to https://github.com/succinctlabs/sp1-contracts/blob/main/contracts/deployments/
+# If you want to use the official pre-deployed gateway, please refer to https://github.com/succinctlabs/sp1-contracts/blob/main/contracts/deployments/
 # and export SP1_VERIFIER=$sp1VerifierAddr
+# Otherwise, deploySP1Verifier() deploys the bundled SP1 v6.1.0 Groth16 verifier.
 $ forge script script/NitroEnclaveVerifier.s.sol --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --sig 'deploySP1Verifier()'
 
 # Deploy the Risc0Verifier

--- a/contracts/DEPLOYMENT.md
+++ b/contracts/DEPLOYMENT.md
@@ -103,8 +103,8 @@ Test deployment without broadcasting transactions:
 
 For each chain, the deployment script will:
 
-1. **Check for existing verifiers**: Uses official SP1 and RISC0 verifier addresses if available
-2. **Deploy verifiers if needed**: Deploys new verifiers if not using official ones
+1. **Check for existing verifiers**: Uses official SP1 Gateway and RISC0 verifier addresses if available
+2. **Deploy verifiers if needed**: Deploys new verifiers if not using official ones. The SP1 fallback deploys the bundled v6.1.0 Groth16 verifier.
 3. **Deploy NitroEnclaveVerifier**: Deploys the main attestation verifier contract
 4. **Set root certificate**: Configures the AWS Nitro root certificate
 5. **Configure ZK verifiers**: Sets up SP1 and RISC0 program IDs and verifier addresses

--- a/contracts/script/NitroEnclaveVerifier.s.sol
+++ b/contracts/script/NitroEnclaveVerifier.s.sol
@@ -8,11 +8,9 @@ import {
     INitroEnclaveVerifier
 } from "../src/interfaces/INitroEnclaveVerifier.sol";
 import {NitroEnclaveVerifier} from "../src/NitroEnclaveVerifier.sol";
-import {SP1Verifier} from "@sp1-contracts/v5.0.0/SP1VerifierGroth16.sol";
+import {SP1Verifier} from "@sp1-contracts/v6.1.0/SP1VerifierGroth16.sol";
 import {ControlID, RiscZeroGroth16Verifier} from "@risc0-ethereum/groth16/RiscZeroGroth16Verifier.sol";
-import {SP1VerifierGateway} from "@sp1-contracts/SP1VerifierGateway.sol";
 import {LibString} from "@solady/utils/LibString.sol";
-import {Ownable} from "@solady/auth/Ownable.sol";
 
 contract NitroEnclaveVerifierScript is Script {
     using LibString for string;


### PR DESCRIPTION
This pull request updates the deployment scripts and documentation to use the latest SP1 v6.1.0 Groth16 verifier and clarifies the use of the SP1 Gateway in both the code and documentation. It also updates the SP1 contracts submodule to a new commit. These changes ensure that the deployment process references the correct verifier versions and provides clearer guidance for users.

**Documentation updates:**

* Updated `README.md` and `DEPLOYMENT.md` to clarify that the official pre-deployed contract is now referred to as the SP1 Gateway, and documented that the fallback deployment uses the bundled SP1 v6.1.0 Groth16 verifier. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L300-R302) [[2]](diffhunk://#diff-c5a1150c681aad8fe52c694ec63a7d51c4b32fe3bc38f21fc9113bec64ebac7aL106-R107)

**Verifier version updates:**

* Updated the import in `NitroEnclaveVerifier.s.sol` to use `SP1Verifier` from `@sp1-contracts/v6.1.0/SP1VerifierGroth16.sol` instead of the older v5.0.0 version.

**Submodule update:**

* Updated the `sp1-contracts` submodule to a newer commit, ensuring the latest contract code is used.